### PR TITLE
fix: subscriber non-subscriptions type error

### DIFF
--- a/subscribers.go
+++ b/subscribers.go
@@ -13,7 +13,7 @@ type Subscriber struct {
 	LastSeen                   time.Time                      `json:"last_seen"`
 	Entitlements               map[string]Entitlement         `json:"entitlements"`
 	Subscriptions              map[string]Subscription        `json:"subscriptions"`
-	NonSubscriptions           map[string]NonSubscription     `json:"non_subscriptions"`
+	NonSubscriptions           map[string][]NonSubscription   `json:"non_subscriptions"`
 	SubscriberAttributes       map[string]SubscriberAttribute `json:"subscriber_attributes"`
 }
 


### PR DESCRIPTION
NonSubscriptions should be a map of NonSubscription array according to [this documentation](https://www.revenuecat.com/reference/subscribers).