### PR TITLE
Add support for sandbox mode, custom HTTP client, and custom API URL in Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Go package for interacting with the [RevenueCat API](https://docs.revenuecat.com
 
 ## Usage
 
-### Example
+### Examples
 
 ```go
 package main
@@ -23,7 +23,34 @@ func main() {
 	sub, _ := rc.GetSubscriber("123")
 	entitled := sub.IsEntitledTo("premium")
 
-	fmt.Println("user entitled: %t", entitled)
+	fmt.Printf("user entitled: %t\n", entitled)
+}
+```
+
+#### Client With Options
+
+```go
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mhemmings/revenuecat"
+)
+
+func main() {
+	customClient := &http.Client{
+		Timeout: 20 * time.Second,
+	}
+
+	rc := revenuecat.New("apikey", revenuecat.WithHTTPClient(customClient), revenuecat.WithSandboxEnabled(true), revenuecat.WithAPIURL("https://custom.api.url/v1/"))
+
+	sub, _ := rc.GetSubscriber("123")
+	entitled := sub.IsEntitledTo("premium")
+
+	fmt.Printf("user entitled: %t\n", entitled)
 }
 ```
 

--- a/client_test.go
+++ b/client_test.go
@@ -60,6 +60,14 @@ func (c *mockClient) expectXPlatform(t *testing.T, expected string) {
 	}
 }
 
+func (c *mockClient) expectXIsSandbox(t *testing.T, expected string) {
+	t.Helper()
+
+	if sandbox := c.request.Header.Get("x-is-sandbox"); sandbox != expected {
+		t.Errorf("expected x-is-sandbox: %q, got x-is-sandbox: %q", expected, sandbox)
+	}
+}
+
 func (c *mockClient) expectBody(t *testing.T, expected string) {
 	t.Helper()
 	bodyBytes, err := ioutil.ReadAll(c.request.Body)

--- a/subscribers_test.go
+++ b/subscribers_test.go
@@ -20,6 +20,36 @@ func TestGetSubscriber(t *testing.T) {
 	cl.expectPath(t, "/v1/subscribers/123")
 }
 
+func TestGetSubscriberSandbox(t *testing.T) {
+	cl := newMockClient(t, 200, nil, nil)
+	rc := New("apikey", WithSandboxEnabled(true))
+	rc.http = cl
+
+	_, err := rc.GetSubscriber("123")
+	if err != nil {
+		t.Errorf("error: %v", err)
+	}
+
+	cl.expectMethod(t, "GET")
+	cl.expectPath(t, "/v1/subscribers/123")
+	cl.expectXIsSandbox(t, "true")
+}
+
+func TestGetSubscriberSandboxDisabled(t *testing.T) {
+	cl := newMockClient(t, 200, nil, nil)
+	rc := New("apikey", WithSandboxEnabled(false))
+	rc.http = cl
+
+	_, err := rc.GetSubscriber("123")
+	if err != nil {
+		t.Errorf("error: %v", err)
+	}
+
+	cl.expectMethod(t, "GET")
+	cl.expectPath(t, "/v1/subscribers/123")
+	cl.expectXIsSandbox(t, "")
+}
+
 func TestGetSubscriberWithPlatform(t *testing.T) {
 	cl := newMockClient(t, 200, nil, nil)
 	rc := New("apikey")


### PR DESCRIPTION
## Description

Currently, the `Client` is created via the `New` function, but fields such as the API URL, client timeout, and enabling/disabling sandbox are not present. While a user could create their own `Client{...}`, it's better if the user does not have as much control, and instantiating a `Client` should be done via the `New` function. 

This PR introduces the following changes to the `revenuecat` package:
* **Sandbox Mode**: Added an option to enable or disable sandbox mode for the `Client`. This is useful for testing purposes. `sandbox` field already exists in the `Subscription` and `NonSubscription` structs, but the RevenueCat API will only return these values if the `X-Is-Sandbox` header exists and is set to `true`.
* **Custom HTTP Client**: Added an option to set a custom HTTP client for the `Client`. This allows for more flexibility in configuring the HTTP client, such as setting timeouts or using a mock client for testing.
* **Custom API URL**: Added an option to set a custom API URL for the `Client`. This allows for testing against different environments or endpoints.

**_Note_**: Adding the `...Option` parameters to `New` is backwards compatible, and a user does not have to add any options. If no options are given, the same default `*Client` as before will be returned.

## Changes
* Added `WithSandboxEnabled` option to enable or disable sandbox mode.
* Added `WithHTTPClient` option to set a custom HTTP client.
* Added `WithAPIURL` option to set a custom API URL.
* Updated the `New` function to accept these new options.
* Modified the `call` method to include the sandbox header if sandbox mode is enabled.
* Updated the `README.md` to include examples of how to use the new options.

## Example Usage
```go
package main

import (
 "fmt"
 "net/http"
 "time"

 "github.com/mhemmings/revenuecat"
)

func main() {
 customClient := &http.Client{
  Timeout: 20 * time.Second,
 }

 rc := revenuecat.New("apikey", revenuecat.WithHTTPClient(customClient), revenuecat.WithSandboxEnabled(true), revenuecat.WithAPIURL("https://custom.api.url/v1/"))

 sub, _ := rc.GetSubscriber("123")
 entitled := sub.IsEntitledTo("premium")

 fmt.Printf("user entitled: %t\n", entitled)
}
```

## Checklist

- [x] Added tests for new functionality
- [x] Updated documentation
- [x] Verified that existing tests pass