### PR TITLE
add ProductPlanIdentifier and GracePeriodExpiresDate to entitlements

### DIFF
--- a/subscribers.go
+++ b/subscribers.go
@@ -19,9 +19,11 @@ type Subscriber struct {
 
 // https://docs.revenuecat.com/reference#the-entitlement-object
 type Entitlement struct {
-	ExpiresDate       time.Time `json:"expires_date"`
-	PurchaseDate      time.Time `json:"purchase_date"`
-	ProductIdentifier string    `json:"product_identifier"`
+	ExpiresDate            time.Time  `json:"expires_date"`
+	GracePeriodExpiresDate *time.Time `json:"grace_period_expires_date"`
+	PurchaseDate           time.Time  `json:"purchase_date"`
+	ProductIdentifier      string     `json:"product_identifier"`
+	ProductPlanIdentifier  string     `json:"product_plan_identifier"`
 }
 
 // https://docs.revenuecat.com/reference#the-subscription-object


### PR DESCRIPTION
`GracePeriodExpiresDate` and `ProductPlanIdentifier` are missing from the `Entitlements` struct.

`GracePeriodExpiresDate` is nullable, which is why it is a pointer (so it does not get defaulted to `0001-01-01 00:00:00 +0000` when null). 

`ProductPlanIdentifier` is not properly documented in the RevenueCat docs, however it is discussed [here](https://community.revenuecat.com/third-party-integrations-53/android-subscription-adding-base-plan-id-to-product-id-2710) and [here](https://www.revenuecat.com/docs/getting-started/entitlements/google-subscriptions-and-backwards-compatibility#revenuecat-sdk-version-support) - and exists in the [official SDK](https://sdk.revenuecat.com/android/8.1.0/purchases/com.revenuecat.purchases/-entitlement-info/product-plan-identifier.html).
