### PR TITLE
Add Product Plan ID to subscription struct

### DIFF
--- a/subscribers.go
+++ b/subscribers.go
@@ -41,6 +41,7 @@ type Subscription struct {
 	RefundedAt              *time.Time    `json:"refunded_at"`
 	OwnershipType           OwnershipType `json:"ownership_type"`
 	StoreTransactionID      string        `json:"store_transaction_id"`
+	ProductPlanIdentifier   string        `json:"product_plan_identifier"`
 }
 
 // https://docs.revenuecat.com/reference#section-the-non-subscription-object


### PR DESCRIPTION
This PR adds Product Plan ID to the `Subscription` struct, similar to `Entitlements`. 

This should be the last of the PRs for these changes.

Example Subscriptions response:
```json
"subscriptions": {
    "foo.bar": {
        "auto_resume_date": null,
        "billing_issues_detected_at": null,
        "expires_date": "2024-11-15T21:15:20Z",
        "grace_period_expires_date": null,
        "is_sandbox": true,
        "original_purchase_date": "2024-11-15T20:45:25Z",
        "period_type": "normal",
        "product_plan_identifier": "bar-baz-ban",
        "purchase_date": "2024-11-15T20:45:25Z",
        "refunded_at": null,
        "store": "play_store",
        "store_transaction_id": "GPA.abc-123-456-7890",
        "unsubscribe_detected_at": "2024-11-15T21:05:56Z"
    },
    "bar.baz": {
        "auto_resume_date": null,
        "billing_issues_detected_at": null,
        "expires_date": "2024-11-16T20:40:19Z",
        "grace_period_expires_date": null,
        "is_sandbox": false,
        "original_purchase_date": "2024-11-15T20:40:19Z",
        "period_type": "normal",
        "purchase_date": "2024-11-15T20:40:19Z",
        "refunded_at": null,
        "store": "promotional",
        "store_transaction_id": "ancdefg12345678",
        "unsubscribe_detected_at": null
    }
}
```